### PR TITLE
update url for logging

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -2,7 +2,7 @@ tools:
   exceptions: 
     frontend: https://sentry.io/organizations/dcsil/issues/?project=5662565
     backend: https://sentry.io/organizations/dcsil/issues/?project=5603815 
-  logging: /app.log
+  logging: https://github.com/dcsil/Moguls-Analysis/blob/master/app.log
   ci:
     frontend: https://github.com/dcsil/Moguls-Analysis/blob/master/.github/workflows/front-end.yml
     backend: https://github.com/dcsil/Moguls-Analysis/blob/master/.github/workflows/python-app.yml


### PR DESCRIPTION
We try to use sumo logic to keep tracking of all logs but I did not find a way to upload the log file automatically. I uploaded the log file and the URL in service .yml is linked to the file on Github.